### PR TITLE
MacPorts and 'make build-requirements' update

### DIFF
--- a/index.html
+++ b/index.html
@@ -738,7 +738,7 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     </p>
     <!-- http://www.macports.org/ports.php -->
     <pre>sudo port install \
-    gdk-pixbuf2 glib2 intltool p5-xml-parser p7zip gpatch scons wget xz</pre>
+    cmake gdk-pixbuf2 glib2 intltool p5-xml-parser p7zip gpatch gsed scons wget xz</pre>
     <h5 id="requirements-macos-method-2">Method 2 - Rudix</h5>
     <p>
     Install <a href="http://rudix.org/">Rudix</a> you can make it with following command
@@ -751,7 +751,7 @@ USE_OSGPLUGIN(&lt;plugin2&gt;)
     <pre>sudo rudix install glib pkg-config scons wget xz</pre>
     Note: <b>gdk-pixbuf2</b> is not installed in method 2,
     so you can not build <b>gtk3</b>.
-    <h4 id="requirements-macos-step-2">Step 2</h4>
+    <h4 id="requirements-macos-step-2">Step 2 (optional)</h4>
     <p>
     After installing pre-requirement run from within the mxe directory:
     </p>


### PR DESCRIPTION
Updated the required MacPorts ports to install on OS X and marked the `make build-requirements` step as optional